### PR TITLE
Guest View Pulls from Firebase

### DIFF
--- a/tasm-tour/src/App.js
+++ b/tasm-tour/src/App.js
@@ -5,8 +5,8 @@ import './App.css';
 
 
 function App() {
-  const qprams = new URLSearchParams(window.location.search);
-  const [exhibitID, setExhibitID] = useState(qprams.get('exhibitID') || 'test');
+  const searchParams = new URLSearchParams(window.location.search);
+  const [exhibitID, setExhibitID] = useState(searchParams.get('exhibitID') || 'test');
 
   console.log(exhibitID);
   return (

--- a/tasm-tour/src/App.js
+++ b/tasm-tour/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Header from './components/Header/Header';
 import ExhibitPage from './components/ExhibitPage/ExhibitPage';
 import './App.css';

--- a/tasm-tour/src/App.js
+++ b/tasm-tour/src/App.js
@@ -1,26 +1,18 @@
-import React from 'react';
+import React , {useState} from 'react';
 import Header from './components/Header/Header';
 import ExhibitPage from './components/ExhibitPage/ExhibitPage';
 import './App.css';
-import ExhibitTitle from './components/ExhibitTitle/ExhibitTitle';
-import ModelView from './components/AFrame/ModelView';
-import ButtonPanel from './components/ButtonPanel/ButtonPanel';
+
 
 function App() {
+  const qprams = new URLSearchParams(window.location.search)
+  const [exhibitID , setExhibitID] = useState(qprams.get('exhibitID')||'test');
+
+  console.log(exhibitID); 
   return (
-    <div className="bg-gray bg-h-screen font-exo2">
-      <Header />
-      <ExhibitTitle title="Rockwell Ranger" />
-      <ModelView modelID="voyager" sky='black'/>
-      <p>Amidst the vast expanse of azure, where the horizon meets the heavens, lies the realm of flight where dreams take wing. In this realm of soaring aspirations, the Loral ISPLUM emerges as a beacon of innovation and excellence. Its sleek design, crafted with precision and passion, embodies the spirit of adventure that defines the aviation industry.
-
-  As the sun kisses the fuselage, casting a golden hue upon its surface, the Loral ISPLUM prepares to embark on its journey. With engines roaring to life, it gracefully ascends into the boundless sky, defying gravity with effortless grace.
-
-  Within its luxurious cabin, passengers are enveloped in comfort and sophistication. From plush seating to state-of-the-art entertainment systems, every detail is meticulously curated to ensure a seamless travel experience. As the aircraft cruises at cruising altitude, travelers gaze out of the panoramic windows, marveling at the world below.
-
-  Meanwhile, in the cockpit, skilled pilots navigate the skies with ex</p>
-      <ButtonPanel />
-      {/* <ExhibitPage /> */}
+    <div className="bg-gray ld-h-screen bg-h-screen font-exo2">
+       <Header exhibitID={exhibitID} setExhibitID={setExhibitID}/>
+      <ExhibitPage exhibitID={exhibitID}/>
     </div>
   );
 }

--- a/tasm-tour/src/App.js
+++ b/tasm-tour/src/App.js
@@ -8,7 +8,6 @@ function App() {
   const searchParams = new URLSearchParams(window.location.search);
   const [exhibitID, setExhibitID] = useState(searchParams.get('exhibitID') || 'test');
 
-  console.log(exhibitID);
   return (
     <div className="bg-gray ld-h-screen bg-h-screen font-exo2">
       <Header exhibitID={exhibitID} setExhibitID={setExhibitID} />

--- a/tasm-tour/src/App.js
+++ b/tasm-tour/src/App.js
@@ -1,18 +1,18 @@
-import React , {useState} from 'react';
+import React, { useState } from 'react';
 import Header from './components/Header/Header';
 import ExhibitPage from './components/ExhibitPage/ExhibitPage';
 import './App.css';
 
 
 function App() {
-  const qprams = new URLSearchParams(window.location.search)
-  const [exhibitID , setExhibitID] = useState(qprams.get('exhibitID')||'test');
+  const qprams = new URLSearchParams(window.location.search);
+  const [exhibitID, setExhibitID] = useState(qprams.get('exhibitID') || 'test');
 
-  console.log(exhibitID); 
+  console.log(exhibitID);
   return (
     <div className="bg-gray ld-h-screen bg-h-screen font-exo2">
-       <Header exhibitID={exhibitID} setExhibitID={setExhibitID}/>
-      <ExhibitPage exhibitID={exhibitID}/>
+      <Header exhibitID={exhibitID} setExhibitID={setExhibitID} />
+      <ExhibitPage exhibitID={exhibitID} />
     </div>
   );
 }

--- a/tasm-tour/src/components/ExhibitPage/ExhibitPage.js
+++ b/tasm-tour/src/components/ExhibitPage/ExhibitPage.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
-import { getFirestore, query, where, getDocs, collection } from 'firebase/firestore';
-import { app } from '../../firebase';
+import { query, where, getDocs, collection } from 'firebase/firestore';
+import { db } from '../../firebase';
 import ExhibitTitle from '../ExhibitTitle/ExhibitTitle';
 import ModelView from '../AFrame/ModelView';
 import VideoView from '../VideoView/VideoView';
@@ -20,7 +20,6 @@ export default function ExhibitPage({ exhibitID }) {
       setLoading(true);
       setExhibit(null);
       try {
-        const db = getFirestore(app);
         const queryResults = query(collection(db, 'exhibits'), where('fourDigitCode', '==', exhibitID));
         const exhibitResults = await getDocs(queryResults);
         if (!exhibitResults.empty) {

--- a/tasm-tour/src/components/ExhibitPage/ExhibitPage.js
+++ b/tasm-tour/src/components/ExhibitPage/ExhibitPage.js
@@ -77,7 +77,11 @@ export default function ExhibitPage({ exhibitID }) {
     <div className="">
       <ExhibitTitle title={exhibit.title} />
       {media}
-      <p>{exhibit.content}</p>
+      <p
+        className='text-black text-center md:w-2/3 m-auto p-4'
+      >
+        {exhibit.content}
+      </p>
       {exhibit.furtherReading ? <FurtherReading furtherReading={exhibit.furtherReading} /> : null}
       <ButtonPanel />
     </div>

--- a/tasm-tour/src/components/ExhibitPage/ExhibitPage.js
+++ b/tasm-tour/src/components/ExhibitPage/ExhibitPage.js
@@ -21,12 +21,12 @@ export default function ExhibitPage({ exhibitID }) {
       setExhibit(null);
       try {
         const db = getFirestore(app);
-        const q = query( collection(db, 'exhibits'), where('fourDigitCode','==', exhibitID));
+        const q = query(collection(db, 'exhibits'), where('fourDigitCode', '==', exhibitID));
         const exhibitCol = await getDocs(q);
         if (!exhibitCol.empty) {
           const exhibitSnapshot = exhibitCol.docs[0];
           setExhibit(exhibitSnapshot.data());
-          if(exhibitCol.size > 1) {
+          if (exhibitCol.size > 1) {
             console.warn("Multiple exhibits found with the same ID: " + exhibitID);
           }
         } else {

--- a/tasm-tour/src/components/ExhibitPage/ExhibitPage.js
+++ b/tasm-tour/src/components/ExhibitPage/ExhibitPage.js
@@ -16,15 +16,19 @@ export default function ExhibitPage({ exhibitID }) {
 
   useEffect(() => {
     const fetchData = async () => {
+      setError(null);
+      setLoading(true);
+      setExhibit(null);
       try {
         const db = getFirestore(app);
         const q = query( collection(db, 'exhibits'), where('fourDigitCode','==', exhibitID));
-        /*const exhibitRef = doc(db, 'exhibits', exhibitID);
-        const exhibitSnapshot = await getDoc(exhibitRef);*/
         const exhibitCol = await getDocs(q);
         if (!exhibitCol.empty) {
           const exhibitSnapshot = exhibitCol.docs[0];
           setExhibit(exhibitSnapshot.data());
+          if(exhibitCol.size > 1) {
+            console.warn("Multiple exhibits found with the same ID: " + exhibitID);
+          }
         } else {
           setError('Exhibit not found.\n' + exhibitID);
         }

--- a/tasm-tour/src/components/ExhibitPage/ExhibitPage.js
+++ b/tasm-tour/src/components/ExhibitPage/ExhibitPage.js
@@ -21,12 +21,12 @@ export default function ExhibitPage({ exhibitID }) {
       setExhibit(null);
       try {
         const db = getFirestore(app);
-        const q = query(collection(db, 'exhibits'), where('fourDigitCode', '==', exhibitID));
-        const exhibitCol = await getDocs(q);
-        if (!exhibitCol.empty) {
-          const exhibitSnapshot = exhibitCol.docs[0];
+        const queryResults = query(collection(db, 'exhibits'), where('fourDigitCode', '==', exhibitID));
+        const exhibitResults = await getDocs(queryResults);
+        if (!exhibitResults.empty) {
+          const exhibitSnapshot = exhibitResults.docs[0];
           setExhibit(exhibitSnapshot.data());
-          if (exhibitCol.size > 1) {
+          if (exhibitResults.size > 1) {
             console.warn("Multiple exhibits found with the same ID: " + exhibitID);
           }
         } else {
@@ -79,7 +79,7 @@ export default function ExhibitPage({ exhibitID }) {
       <ExhibitTitle title={exhibit.title} />
       {media}
       <p>{exhibit.content}</p>
-      {/* <FurtherReading furtherReading={exhibit.furtherReading} /> */}
+      {exhibit.furtherReading ? <FurtherReading furtherReading={exhibit.furtherReading} /> : null}
       <ButtonPanel />
     </div>
   );

--- a/tasm-tour/src/components/ExhibitTitle/ExhibitTitle.js
+++ b/tasm-tour/src/components/ExhibitTitle/ExhibitTitle.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { SpeakerWaveIcon } from '@heroicons/react/24/solid';
 import Button from '../ButtonPanel/Button';
 

--- a/tasm-tour/src/components/ExhibitTitle/ExhibitTitle.js
+++ b/tasm-tour/src/components/ExhibitTitle/ExhibitTitle.js
@@ -5,9 +5,9 @@ import Button from '../ButtonPanel/Button';
 export default function ExhibitTitle({ title, bodyText }) {
   const handleTextToSpeech = () => {
     const { speechSynthesis } = window;
-    const speech = new SpeechSynthesisUtterance(title + ". . ." +bodyText);
+    const speech = new SpeechSynthesisUtterance(title + ". . ." + bodyText);
     speechSynthesis.speak(speech);
-  }
+  };
 
   return (
     <div className="shadow-lg">

--- a/tasm-tour/src/components/ExhibitTitle/ExhibitTitle.js
+++ b/tasm-tour/src/components/ExhibitTitle/ExhibitTitle.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { SpeakerWaveIcon } from '@heroicons/react/24/solid';
 import Button from '../ButtonPanel/Button';
 
-export default function ExhibitTitle({ title }) {
+export default function ExhibitTitle({ title, bodyText }) {
   const handleTextToSpeech = () => {
     const { speechSynthesis } = window;
-    const speech = new SpeechSynthesisUtterance(title);
+    const speech = new SpeechSynthesisUtterance(title + ". . ." +bodyText);
     speechSynthesis.speak(speech);
   }
 

--- a/tasm-tour/src/components/Header/Header.js
+++ b/tasm-tour/src/components/Header/Header.js
@@ -25,6 +25,11 @@ export default function Header({ exhibitID, setExhibitID }) {
             onChange={handleInputChange}
             onSubmit={console.log(inputValue)}
             className="bg-gray text-black w-24 py-1 px-2 rounded-l-md text-center text-2xl font-bold drop-shadow-[-2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                setExhibitID(inputValue);
+              }
+            }}
           />
           <Button
             className="btn rounded-r-md pr-1 pl-3 py-1 text-xl drop-shadow-[2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"

--- a/tasm-tour/src/components/Header/Header.js
+++ b/tasm-tour/src/components/Header/Header.js
@@ -1,6 +1,7 @@
 import { React, useState} from 'react';
 import logo from '../../assets/images/tasm-logo-p-500.png';
 import {ChevronRightIcon} from '@heroicons/react/24/outline';
+import Button from '../ButtonPanel/Button';
 
 export default function Header({ exhibitID, setExhibitID }) {
   const [inputValue, setInputValue] = useState(exhibitID);
@@ -22,14 +23,18 @@ export default function Header({ exhibitID, setExhibitID }) {
           type='text'
           value={inputValue}
           onChange={handleInputChange}
-          className="bg-gray text-black w-24 py-1 px-2 rounded-l-full text-center text-2xl font-bold drop-shadow-[-2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"
+          onSubmit={console.log(inputValue)}
+          className="bg-gray text-black w-24 py-1 px-2 rounded-l-md text-center text-2xl font-bold drop-shadow-[-2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"
         />
-        <button 
-          className="btn rounded-r-full pr-1 pl-3 py-1 text-xl drop-shadow-[2px_3px_4px_rgba(0,0,0,0.25)]"
+        <Button 
+          className="btn rounded-r-md pr-1 pl-3 py-1 text-xl drop-shadow-[2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"
           onClick={() => setExhibitID(inputValue)}
+          icon={ChevronRightIcon}
+          iconProps={{ className: "w-7 h-7" }}
+          iconPosition="right"
         >
-          {ChevronRightIcon && <ChevronRightIcon className="w-7 h-7" />}
-        </button>
+          
+        </Button>
         </div>
       </div>
 		</div>

--- a/tasm-tour/src/components/Header/Header.js
+++ b/tasm-tour/src/components/Header/Header.js
@@ -1,11 +1,13 @@
 import { React, useState} from 'react';
 import logo from '../../assets/images/tasm-logo-p-500.png';
+import {ChevronRightIcon} from '@heroicons/react/24/outline';
 
-export default function Header({ exhibitID }) {
+export default function Header({ exhibitID, setExhibitID }) {
   const [inputValue, setInputValue] = useState(exhibitID);
 
   const handleInputChange = (event) => {
     setInputValue(event.target.value);
+    console.log(inputValue);
   }
 
 	return (
@@ -15,12 +17,20 @@ export default function Header({ exhibitID }) {
 			</div>
       <div className="m-4 pr-3 font-exo2 text-center">
         <p className="text-white text-2xl font-bold">Go to Exhibit:</p>
+        <div className='flex'>
         <input
           type='text'
           value={inputValue}
           onChange={handleInputChange}
-          className="bg-gray text-black w-36 py-0 px-2 rounded-md text-center text-2xl font-bold shadow-md focus:outline-none focus:ring-2 focus:ring-blue transition-all"
+          className="bg-gray text-black w-24 py-1 px-2 rounded-l-full text-center text-2xl font-bold drop-shadow-[-2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"
         />
+        <button 
+          className="btn rounded-r-full pr-1 pl-3 py-1 text-xl drop-shadow-[2px_3px_4px_rgba(0,0,0,0.25)]"
+          onClick={() => setExhibitID(inputValue)}
+        >
+          {ChevronRightIcon && <ChevronRightIcon className="w-7 h-7" />}
+        </button>
+        </div>
       </div>
 		</div>
 	);

--- a/tasm-tour/src/components/Header/Header.js
+++ b/tasm-tour/src/components/Header/Header.js
@@ -1,6 +1,6 @@
-import { React, useState} from 'react';
+import { React, useState } from 'react';
 import logo from '../../assets/images/tasm-logo-p-500.png';
-import {ChevronRightIcon} from '@heroicons/react/24/outline';
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import Button from '../ButtonPanel/Button';
 
 export default function Header({ exhibitID, setExhibitID }) {
@@ -9,34 +9,34 @@ export default function Header({ exhibitID, setExhibitID }) {
   const handleInputChange = (event) => {
     setInputValue(event.target.value);
     console.log(inputValue);
-  }
+  };
 
-	return (
-		<div className="bg-tasm-header-bg bg-no-repeat bg-cover bg-right-top flex justify-between items-center">
-			<div>
-				<img src={logo} alt='TASM Logo' className="object-scale-down h-24 m-2" />
-			</div>
+  return (
+    <div className="bg-tasm-header-bg bg-no-repeat bg-cover bg-right-top flex justify-between items-center">
+      <div>
+        <img src={logo} alt='TASM Logo' className="object-scale-down h-24 m-2" />
+      </div>
       <div className="m-4 pr-3 font-exo2 text-center">
         <p className="text-white text-2xl font-bold">Go to Exhibit:</p>
         <div className='flex'>
-        <input
-          type='text'
-          value={inputValue}
-          onChange={handleInputChange}
-          onSubmit={console.log(inputValue)}
-          className="bg-gray text-black w-24 py-1 px-2 rounded-l-md text-center text-2xl font-bold drop-shadow-[-2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"
-        />
-        <Button 
-          className="btn rounded-r-md pr-1 pl-3 py-1 text-xl drop-shadow-[2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"
-          onClick={() => setExhibitID(inputValue)}
-          icon={ChevronRightIcon}
-          iconProps={{ className: "w-7 h-7" }}
-          iconPosition="right"
-        >
-          
-        </Button>
+          <input
+            type='text'
+            value={inputValue}
+            onChange={handleInputChange}
+            onSubmit={console.log(inputValue)}
+            className="bg-gray text-black w-24 py-1 px-2 rounded-l-md text-center text-2xl font-bold drop-shadow-[-2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"
+          />
+          <Button
+            className="btn rounded-r-md pr-1 pl-3 py-1 text-xl drop-shadow-[2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"
+            onClick={() => setExhibitID(inputValue)}
+            icon={ChevronRightIcon}
+            iconProps={{ className: "w-7 h-7" }}
+            iconPosition="right"
+          >
+
+          </Button>
         </div>
       </div>
-		</div>
-	);
+    </div>
+  );
 }

--- a/tasm-tour/src/components/Header/Header.js
+++ b/tasm-tour/src/components/Header/Header.js
@@ -1,4 +1,4 @@
-import { React, useState } from 'react';
+import { useState } from 'react';
 import logo from '../../assets/images/tasm-logo-p-500.png';
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import Button from '../ButtonPanel/Button';
@@ -8,7 +8,6 @@ export default function Header({ exhibitID, setExhibitID }) {
 
   const handleInputChange = (event) => {
     setInputValue(event.target.value);
-    console.log(inputValue);
   };
 
   return (
@@ -25,8 +24,8 @@ export default function Header({ exhibitID, setExhibitID }) {
             onChange={handleInputChange}
             onSubmit={console.log(inputValue)}
             className="bg-gray text-black w-24 py-1 px-2 rounded-l-md text-center text-2xl font-bold drop-shadow-[-2px_3px_4px_rgba(0,0,0,0.25)] focus:outline-none focus:ring-2 focus:ring-blue transition-all"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
                 setExhibitID(inputValue);
               }
             }}

--- a/tasm-tour/src/components/VideoView/VideoView.js
+++ b/tasm-tour/src/components/VideoView/VideoView.js
@@ -13,7 +13,8 @@ export default function VideoView({ videoPath, ariaLabel, caption, displayType =
         style={{height:'500px'}}
         allowfullscreen="true"
         src={videoPath} 
-        aria-label={alt} />
+        aria-label={alt} 
+        title={alt}/>
       {caption ? <p style={{ textAlign: 'center' }}>{caption}</p> : null}
     </div>
   );

--- a/tasm-tour/src/components/VideoView/VideoView.js
+++ b/tasm-tour/src/components/VideoView/VideoView.js
@@ -9,12 +9,12 @@ export default function VideoView({ videoPath, ariaLabel, caption, displayType =
   return (
     <div>
       <iframe
-        className={display + " md:w-2/3  m-auto"} 
-        style={{height:'500px'}}
+        className={display + " md:w-2/3  m-auto"}
+        style={{ height: '500px' }}
         allowfullscreen="true"
-        src={videoPath} 
-        aria-label={alt} 
-        title={alt}/>
+        src={videoPath}
+        aria-label={alt}
+        title={alt} />
       {caption ? <p style={{ textAlign: 'center' }}>{caption}</p> : null}
     </div>
   );

--- a/tasm-tour/src/firebase.js
+++ b/tasm-tour/src/firebase.js
@@ -1,6 +1,7 @@
 // src/firebase.js
 import { initializeApp } from 'firebase/app';
 import { getAnalytics } from 'firebase/analytics';
+import { getFirestore } from 'firebase/firestore';
 // import 'firebase/analytics';
 // import 'firebase/hosting';
 // import 'firebase/auth';
@@ -17,5 +18,6 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const analytics = getAnalytics(app);
+const db = getFirestore(app);
 
-export { app, analytics };
+export { app, analytics, db };


### PR DESCRIPTION
- The guest view now pulls data from firebase.
- Currently if no exhibitID(fourDigitCode) is provided it opens to 'test'
- We'll want to change from 'test' to maybe 'home' or something of the sort.
- Button for 'Go To' may need updated styleling
- This also loads in the exhibit from the URL

# Examples:
![image](https://github.com/WoodsonTD/TASM-self-guided-tour/assets/6739968/4d58f957-e498-4222-8cc8-59e155ea176a)
the exhibit I gave the fourDigitCode of 1234
![image](https://github.com/WoodsonTD/TASM-self-guided-tour/assets/6739968/58f0cdb0-4571-4ae7-ab92-7cb740ef141c)
After using Go To Exhibit to go to the page with the code 'test'
![image](https://github.com/WoodsonTD/TASM-self-guided-tour/assets/6739968/e030ac33-2585-4cbe-818c-0536e1017e3a)
Url of 1234
![image](https://github.com/WoodsonTD/TASM-self-guided-tour/assets/6739968/5456f1a6-6017-4fcf-8de6-df52c11d47ff)
URL of test