### PR TITLE
User is redirected to the "home" page of the staff editor after clicking submit

### DIFF
--- a/tasm-staff-editor/src/components/EditorView/ExhibitForm.js
+++ b/tasm-staff-editor/src/components/EditorView/ExhibitForm.js
@@ -143,6 +143,8 @@ function ExhibitForm({ entry, setEntry, handleDelete }) {
       // Update the exhibit data in Firestore with the 4-digit code
       await updateDoc(docRef, exhibitData);
       alert('Exhibit data saved successfully!');
+      setEntry(null);
+      setIsAddingNew(false);
     } catch (error) {
       console.error('Error saving exhibit data:', error);
     }


### PR DESCRIPTION
User is redirected to the "home" page of the staff editor after clicking submit to add changes or update an existing exhibit page